### PR TITLE
Add GCS deployment status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A minimalist terminal-inspired website.
 
-[![GCS Deployment Status](https://img.shields.io/badge/GCS%20Deployment-active-success)](https://broken.dev)
+[![GCS Deployment Status](https://github.com/patflynn/broken-web/actions/workflows/deploy.yml/badge.svg)](https://github.com/patflynn/broken-web/actions/workflows/deploy.yml) [![Live Site](https://img.shields.io/badge/Live%20Site-broken.dev-blue)](https://broken.dev)
 
 ## Development
 


### PR DESCRIPTION
## Summary
- Added a visual badge indicator showing that main branch is successfully deployed to GCS
- Badge links to the live site for easy access

## Test plan
- Verify badge appears correctly in the README
- Confirm link works and directs to the live site

🤖 Generated with [Claude Code](https://claude.ai/code)