### PR TITLE
Fix GCS bucket URL in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,18 +30,29 @@ jobs:
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           
+      # Step 1: Deploy all files from public directory
       - name: Deploy public directory to Google Cloud Storage
         run: |
-          echo "Deploying public directory to ${{ secrets.GCS_BUCKET_NAME }}"
-          gsutil -m rsync -r public/ gs://${{ secrets.GCS_BUCKET_NAME }}/
+          echo "Deploying public directory to broken.dev"
+          gsutil -m rsync -r public/ gs://broken.dev/
+          echo "Listing bucket contents:"
+          gsutil ls gs://broken.dev/
           
+      # Step 2: Apply GCS bucket configurations
       - name: Configure GCS bucket
         run: |
+          # Set CORS policy
           echo "Setting CORS policy"
-          gsutil cors set config/cors.json gs://${{ secrets.GCS_BUCKET_NAME }}
+          gsutil cors set config/cors.json gs://broken.dev
           
+          # Set website configuration
           echo "Setting website configuration"
-          gsutil web set -m index.html -e 404.html gs://${{ secrets.GCS_BUCKET_NAME }}
+          gsutil web set -m index.html -e 404.html gs://broken.dev
           
+          # Set public access
           echo "Setting public access"
-          gsutil iam ch allUsers:objectViewer gs://${{ secrets.GCS_BUCKET_NAME }}
+          gsutil iam ch allUsers:objectViewer gs://broken.dev
+          
+          # Verify configuration
+          echo "Verifying website configuration"
+          gsutil web get gs://broken.dev


### PR DESCRIPTION
## Summary
- Fixed deployment workflow by replacing empty GCS_BUCKET_NAME secret with direct bucket name "broken.dev"
- Resolves the InvalidUrlError: Cloud URL scheme should be followed by colon and two slashes issue

## Test plan
- Verify the deployment workflow succeeds
- Check that files are deployed correctly to the GCS bucket

🤖 Generated with [Claude Code](https://claude.ai/code)